### PR TITLE
Support template variables for selecting individual activity

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from '../types';
 import StravaDatasource from '../datasource';
 import { AthleteLabel } from './AthleteLabel';
+import { getTemplateSrv } from '@grafana/runtime';
 
 const ACTIVITY_DATE_FORMAT = 'YYYY-MM-DD HH:mm';
 
@@ -159,11 +160,19 @@ export class QueryEditor extends PureComponent<Props, State> {
     const { datasource } = this.props;
     let activities = await datasource.stravaApi.getActivities({ limit: 100 });
     activities = datasource.filterActivities(activities, activityType);
-    const options: Array<SelectableValue<number>> = activities.map((a) => ({
+    let options: Array<SelectableValue<number>> = activities.map((a) => ({
       value: a.id,
       label: a.name,
       description: `${dateTime(a.start_date_local).format(ACTIVITY_DATE_FORMAT)} (${a.type})`,
     }));
+
+    const variables: Array<SelectableValue> = getTemplateSrv().getVariables().map(v => ({
+      value: `$${v.name}`,
+      label: `$${v.name}`,
+      description: 'Variable'
+    }));
+    options = variables.concat(options);
+
     return options;
   };
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -166,11 +166,13 @@ export class QueryEditor extends PureComponent<Props, State> {
       description: `${dateTime(a.start_date_local).format(ACTIVITY_DATE_FORMAT)} (${a.type})`,
     }));
 
-    const variables: Array<SelectableValue> = getTemplateSrv().getVariables().map(v => ({
-      value: `$${v.name}`,
-      label: `$${v.name}`,
-      description: 'Variable'
-    }));
+    const variables: SelectableValue[] = getTemplateSrv()
+      .getVariables()
+      .map((v) => ({
+        value: `$${v.name}`,
+        label: `$${v.name}`,
+        description: 'Variable',
+      }));
     options = variables.concat(options);
 
     return options;

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -18,16 +18,14 @@ export interface VariableQueryProps {
 }
 
 export class StravaVariableQueryEditor extends PureComponent<VariableQueryProps> {
-  queryTypes: Array<SelectableValue<VariableQueryTypes>> = [
-    { value: VariableQueryTypes.Activity, label: 'Activity'},
-  ];
+  queryTypes: Array<SelectableValue<VariableQueryTypes>> = [{ value: VariableQueryTypes.Activity, label: 'Activity' }];
 
   onQueryTypeChange = (selectedItem: SelectableValue<VariableQueryTypes>) => {
     const queryType = selectedItem.value || VariableQueryTypes.Activity;
 
     const queryModel: VariableQuery = { ...this.props.query, queryType };
     this.props.onChange(queryModel, `Strava - ${queryType}`);
-  }
+  };
 
   onActivityTypeChange = (selectedItem: SelectableValue<StravaActivityType>) => {
     const activityType = selectedItem.value || '';
@@ -35,7 +33,7 @@ export class StravaVariableQueryEditor extends PureComponent<VariableQueryProps>
     const queryModel: VariableQuery = { ...this.props.query, activityType };
     console.log(queryModel);
     this.props.onChange(queryModel, `Strava - ${this.props.query.queryType}`);
-  }
+  };
 
   render() {
     const { query } = this.props;
@@ -44,15 +42,10 @@ export class StravaVariableQueryEditor extends PureComponent<VariableQueryProps>
       <>
         <div className="gf-form max-width-21">
           <InlineFormLabel width={10}>Query Type</InlineFormLabel>
-          <Select
-            width={16}
-            value={query.queryType}
-            options={this.queryTypes}
-            onChange={this.onQueryTypeChange}
-          />
+          <Select width={16} value={query.queryType} options={this.queryTypes} onChange={this.onQueryTypeChange} />
         </div>
         <div className="gf-form-inline">
-          {query.queryType == VariableQueryTypes.Activity && (
+          {query.queryType === VariableQueryTypes.Activity && (
             <div className="gf-form max-width-30">
               <InlineFormLabel width={10}>Activity Type</InlineFormLabel>
               <Select

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,70 @@
+import React, { PureComponent } from 'react';
+import { SelectableValue } from '@grafana/data';
+import { VariableQueryTypes, StravaActivityType, VariableQuery } from '../types';
+import { InlineFormLabel, Select } from '@grafana/ui';
+
+const stravaActivityTypeOptions: Array<SelectableValue<StravaActivityType>> = [
+  { value: '', label: 'All' },
+  { value: 'Run', label: 'Run' },
+  { value: 'Ride', label: 'Ride' },
+  { value: 'Other', label: 'Other' },
+];
+
+export interface VariableQueryProps {
+  query: VariableQuery;
+  onChange: (query: VariableQuery, definition: string) => void;
+  datasource: any;
+  templateSrv: any;
+}
+
+export class StravaVariableQueryEditor extends PureComponent<VariableQueryProps> {
+  queryTypes: Array<SelectableValue<VariableQueryTypes>> = [
+    { value: VariableQueryTypes.Activity, label: 'Activity'},
+  ];
+
+  onQueryTypeChange = (selectedItem: SelectableValue<VariableQueryTypes>) => {
+    const queryType = selectedItem.value || VariableQueryTypes.Activity;
+
+    const queryModel: VariableQuery = { ...this.props.query, queryType };
+    this.props.onChange(queryModel, `Strava - ${queryType}`);
+  }
+
+  onActivityTypeChange = (selectedItem: SelectableValue<StravaActivityType>) => {
+    const activityType = selectedItem.value || '';
+
+    const queryModel: VariableQuery = { ...this.props.query, activityType };
+    console.log(queryModel);
+    this.props.onChange(queryModel, `Strava - ${this.props.query.queryType}`);
+  }
+
+  render() {
+    const { query } = this.props;
+
+    return (
+      <>
+        <div className="gf-form max-width-21">
+          <InlineFormLabel width={10}>Query Type</InlineFormLabel>
+          <Select
+            width={16}
+            value={query.queryType}
+            options={this.queryTypes}
+            onChange={this.onQueryTypeChange}
+          />
+        </div>
+        <div className="gf-form-inline">
+          {query.queryType == VariableQueryTypes.Activity && (
+            <div className="gf-form max-width-30">
+              <InlineFormLabel width={10}>Activity Type</InlineFormLabel>
+              <Select
+                width={16}
+                value={query.activityType}
+                onChange={this.onActivityTypeChange}
+                options={stravaActivityTypeOptions}
+              />
+            </div>
+          )}
+        </div>
+      </>
+    );
+  }
+}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -14,6 +14,7 @@ import {
   ArrayVector,
   MutableDataFrame,
   TIME_SERIES_VALUE_FIELD_NAME,
+  MetricFindValue,
 } from '@grafana/data';
 import StravaApi from './stravaApi';
 import polyline from './polyline';
@@ -28,6 +29,7 @@ import {
   StravaActivityStream,
   StravaActivityData,
   StravaSplitStat,
+  VariableQuery,
 } from './types';
 import { smoothVelocityData, velocityDataToPace, velocityDataToSpeed, velocityToSpeed } from 'utils';
 
@@ -247,6 +249,16 @@ export default class StravaDatasource extends DataSourceApi<StravaQuery, StravaJ
     frame.addField(valueFiled);
 
     return frame;
+  }
+
+  async metricFindQuery(query: VariableQuery, options?: any): Promise<MetricFindValue[]> {
+    let activities = await this.stravaApi.getActivities({ limit: 100 });
+    activities = this.filterActivities(activities, query.activityType);
+    const variableOptions: MetricFindValue[] = activities.map((a) => ({
+      value: a.id,
+      text: a.name,
+    }));
+    return variableOptions;
   }
 
   async testDatasource() {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -32,6 +32,7 @@ import {
   VariableQuery,
 } from './types';
 import { smoothVelocityData, velocityDataToPace, velocityDataToSpeed, velocityToSpeed } from 'utils';
+import { getTemplateSrv } from '@grafana/runtime';
 
 const DEFAULT_RANGE = {
   from: dateTime(),
@@ -107,8 +108,9 @@ export default class StravaDatasource extends DataSourceApi<StravaQuery, StravaJ
   }
 
   async queryActivity(options: DataQueryRequest<StravaQuery>, target: StravaQuery) {
+    const activityId = getTemplateSrv().replace(target.activityId?.toString());
     const activity = await this.stravaApi.getActivity({
-      id: target.activityId,
+      id: activityId,
       include_all_efforts: true,
     });
 
@@ -126,7 +128,7 @@ export default class StravaDatasource extends DataSourceApi<StravaQuery, StravaJ
     }
 
     const streams = await this.stravaApi.getActivityStreams({
-      id: target.activityId,
+      id: activityId,
       streamType: activityStream,
     });
 

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,4 +1,5 @@
 import { DataSourcePlugin } from '@grafana/data';
+import { StravaVariableQueryEditor } from './components/VariableQueryEditor';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
 import StravaDatasource from './datasource';
@@ -11,4 +12,5 @@ class StravaAnnotationsQueryCtrl {
 export const plugin = new DataSourcePlugin<StravaDatasource, StravaQuery, StravaJsonData>(StravaDatasource)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor)
-  .setAnnotationQueryCtrl(StravaAnnotationsQueryCtrl);
+  .setAnnotationQueryCtrl(StravaAnnotationsQueryCtrl)
+  .setVariableQueryEditor(StravaVariableQueryEditor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,3 +87,12 @@ export enum StravaActivityStream {
   GradeSmooth = 'grade_smooth',
   GradeAdjustedDistance = 'grade_adjusted_distance',
 }
+
+export interface VariableQuery {
+  queryType: VariableQueryTypes;
+  activityType: string;
+}
+
+export enum VariableQueryTypes {
+  Activity = 'activity',
+}


### PR DESCRIPTION
This PR introduces initial template variables support. You can create variable which returns activities and then use it for selecting activity data. Thus, it's possible to create reusable dashboard for analyzing activity.

![Screenshot from 2021-04-30 14-16-57](https://user-images.githubusercontent.com/4932851/116688150-f0935580-a9be-11eb-8a9c-2565fac89c2e.png)
