### PR TITLE
Bug fixes v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.5.1] - 2022-09-08
+
+### Fixed
+
+- 401 Unauthorized when connecting to Strava API, [#62](https://github.com/grafana/strava-datasource/issues/62)
+
 ## [1.5.0] - 2022-08-24
 
 ### Added

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  # Grafana
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3001:3000"
+    volumes:
+      - ..:/strava-datasource
+      - ./grafana.ini:/etc/grafana/grafana.ini:ro

--- a/devenv/grafana.ini
+++ b/devenv/grafana.ini
@@ -1,0 +1,10 @@
+app_mode = development
+
+[log]
+level = debug
+
+[plugins]
+enable_alpha = true
+
+[plugin.strava-datasource]
+path = /strava-datasource

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grafana-strava-datasource",
   "description": "Strava Datasource for Grafana",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "https://grafana.com/plugins/grafana-strava-datasource",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "SEE LICENSE IN LICENSE",

--- a/pkg/datasource/authcache.go
+++ b/pkg/datasource/authcache.go
@@ -1,0 +1,63 @@
+/*
+	This module contains a very simple cache for auth info (like refresh token) which is persisted
+	for plugin process lifetime. This is required because when plugin settings are updated, new plugin instance is
+	created and previously cached data is not available anymore.
+*/
+package datasource
+
+import "sync"
+
+type AuthCache struct {
+	cache map[int64]*DSAuthCache
+	m     sync.Mutex
+}
+
+type DSAuthCache struct {
+	refreshToken string
+	m            sync.Mutex
+}
+
+var authCache AuthCache = AuthCache{cache: make(map[int64]*DSAuthCache), m: sync.Mutex{}}
+
+func GetAuthCache() *AuthCache {
+	return &authCache
+}
+
+func GetDSAuthCache(dsId int64) *DSAuthCache {
+	ac := GetAuthCache()
+	if c := ac.getDSAuthCache(dsId); c != nil {
+		return c
+	} else {
+		return ac.initDSAuthCache(dsId)
+	}
+}
+
+func (c *AuthCache) initDSAuthCache(dsId int64) *DSAuthCache {
+	dsCache := &DSAuthCache{m: sync.Mutex{}}
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.cache[dsId] = dsCache
+	return dsCache
+}
+
+func (c *AuthCache) getDSAuthCache(dsId int64) *DSAuthCache {
+	c.m.Lock()
+	dsCache, ok := c.cache[dsId]
+	c.m.Unlock()
+	if ok {
+		return dsCache
+	}
+	return nil
+}
+
+func (d *DSAuthCache) GetRefreshToken() string {
+	d.m.Lock()
+	defer d.m.Unlock()
+	return d.refreshToken
+}
+
+func (d *DSAuthCache) SetRefreshToken(t string) {
+	d.m.Lock()
+	d.refreshToken = t
+	d.m.Unlock()
+}

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -226,6 +226,7 @@ func (ds *StravaDatasourceInstance) GetRefreshToken() (string, error) {
 				return "", errors.New("Refresh token not found, authorize datasource first")
 			}
 			ds.logger.Debug("Refresh token loaded from file")
+			ds.authCache.SetRefreshToken(refreshToken)
 			return refreshToken, nil
 		} else {
 			refreshToken = refreshTokenCached.(string)

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -354,15 +354,16 @@ func (ds *StravaDatasourceInstance) RefreshAccessToken(refreshToken string) (*To
 func (ds *StravaDatasourceInstance) ResetAccessToken() error {
 	ds.cache.Delete("accessToken")
 	ds.logger.Debug("Access token removed from cache")
-	ds.ResetCache()
 	return nil
 }
 
 func (ds *StravaDatasourceInstance) ResetCache() {
-	refreshToken, _ := ds.cache.Get("refreshToken")
+	refreshToken, found := ds.cache.Get("refreshToken")
 	ds.cache.Flush()
 	// Do not remove refresh token from cache
-	ds.cache.SetWithExpiration("refreshToken", refreshToken, cache.NoExpiration)
+	if found {
+		ds.cache.SetWithExpiration("refreshToken", refreshToken.(string), cache.NoExpiration)
+	}
 	ds.logger.Info("Cache has been reset", "data source", ds.dsInfo.Name)
 }
 

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -109,7 +109,9 @@ func newStravaDatasourceInstance(settings backend.DataSourceInstanceSettings, da
 	// Initialize and run prefetcher
 	prefetcher := NewStravaPrefetcher(5, dsInstance)
 	dsInstance.prefetcher = prefetcher
-	dsInstance.prefetcher.Run()
+	go func() {
+		dsInstance.prefetcher.Run()
+	}()
 
 	return dsInstance, nil
 }

--- a/pkg/datasource/dscache.go
+++ b/pkg/datasource/dscache.go
@@ -75,7 +75,13 @@ func (c *DSCache) Save(request string, response interface{}) error {
 	cacheKey := c.buildDSCacheKey(request)
 	filename := filepath.Join(c.dataDir, cacheKey)
 	cacheLogger.Debug("Saving key to file", "key", request, "path", filename)
-	return os.WriteFile(filename, []byte(response.(string)), 0644)
+	err := os.WriteFile(filename, []byte(response.(string)), 0644)
+	if err != nil {
+		cacheLogger.Error("Error saving data, switching to default directory", "dir", c.dataDir, "error", err)
+		c.dataDir = ""
+		return os.WriteFile(filepath.Join(c.dataDir, cacheKey), []byte(response.(string)), 0644)
+	}
+	return nil
 }
 
 // Load value from disk

--- a/pkg/datasource/prefetcher.go
+++ b/pkg/datasource/prefetcher.go
@@ -35,7 +35,6 @@ func (p *StravaPrefetcher) Run() {
 		log.DefaultLogger.Error("Error fetching activities", "error", err)
 		return
 	}
-	log.DefaultLogger.Debug("Activities", "value", activities)
 
 	p.PrefetchActivitiesVariable(10)
 	p.PrefetchActivitiesVariable(100)
@@ -71,6 +70,7 @@ func (p *StravaPrefetcher) GetActivities() ([]string, error) {
 }
 
 func (p *StravaPrefetcher) PrefetchActivities(activities []string) {
+	log.DefaultLogger.Debug("Prefetching activities", "activities", len(activities))
 	queue := make(chan int, MaxTasks)
 	for i := 0; i < p.depth; i++ {
 		activityId := activities[i]
@@ -86,7 +86,6 @@ func (p *StravaPrefetcher) PrefetchActivities(activities []string) {
 func (p *StravaPrefetcher) PrefetchActivity(activityId string) {
 	payloadPattern := `{"datasourceId":%d,"endpoint":"/activities/%s","params":{"include_all_efforts":true}}`
 	payload := fmt.Sprintf(payloadPattern, p.ds.dsInfo.ID, activityId)
-	log.DefaultLogger.Debug("Prefetching", "payload", payload)
 
 	requestHash := HashString(payload)
 	stravaApiQueryFn := p.ds.StravaAPIQueryWithCache(requestHash)
@@ -134,7 +133,6 @@ func (p *StravaPrefetcher) PrefetchActivityStreams(activityId string) {
 
 	for _, task := range prefetchTasks {
 		payload := fmt.Sprintf(task.pattern, p.ds.dsInfo.ID, activityId)
-		log.DefaultLogger.Debug("Prefetching", "payload", payload)
 
 		requestHash := HashString(payload)
 		stravaApiQueryFn := p.ds.StravaAPIQueryWithCache(requestHash)
@@ -150,9 +148,9 @@ func (p *StravaPrefetcher) PrefetchActivityStreams(activityId string) {
 }
 
 func (p *StravaPrefetcher) PrefetchActivitiesVariable(limit int) {
+	log.DefaultLogger.Debug("Prefetching variables", "limit", limit)
 	payloadPattern := `{"datasourceId":%d,"endpoint":"athlete/activities","params":{"limit":%d,"per_page":%d,"page":1}}`
 	payload := fmt.Sprintf(payloadPattern, p.ds.dsInfo.ID, limit, limit)
-	log.DefaultLogger.Debug("Prefetching", "payload", payload)
 
 	requestHash := HashString(payload)
 	stravaApiQueryFn := p.ds.StravaAPIQueryWithCache(requestHash)

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -86,6 +86,30 @@ func (ds *StravaDatasource) ResetAccessTokenHandler(rw http.ResponseWriter, req 
 	rw.Write(b)
 }
 
+func (ds *StravaDatasource) ResetCacheHandler(rw http.ResponseWriter, req *http.Request) {
+	pluginCxt := httpadapter.PluginConfigFromContext(req.Context())
+	dsInstance, err := ds.getDSInstance(pluginCxt)
+	if err != nil {
+		ds.logger.Error("Error loading datasource", "error", err)
+		writeError(rw, http.StatusInternalServerError, err)
+		return
+	}
+
+	dsInstance.ResetCache()
+
+	data := make(map[string]interface{})
+	data["message"] = "Cache flushed"
+	var b []byte
+	if b, err = json.Marshal(data); err != nil {
+		rw.WriteHeader(http.StatusOK)
+		return
+	}
+
+	rw.Header().Add("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	rw.Write(b)
+}
+
 func (ds *StravaDatasource) StravaAPIHandler(rw http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		return

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -50,6 +50,7 @@ func Init(mux *http.ServeMux) *datasource.StravaDatasource {
 	mux.HandleFunc("/auth", ds.StravaAuthHandler)
 	mux.HandleFunc("/strava-api", ds.StravaAPIHandler)
 	mux.HandleFunc("/reset-access-token", ds.ResetAccessTokenHandler)
+	mux.HandleFunc("/reset-cache", ds.ResetCacheHandler)
 
 	return ds
 }

--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -47,7 +47,7 @@ func Init(mux *http.ServeMux) *datasource.StravaDatasource {
 			log.DefaultLogger.Error("Cannot get OS cache directory path", "error", err)
 		}
 		dataDirPath = path.Join(dataDirPath, DEFAULT_DATA_DIR)
-		err = os.Mkdir(dataDirPath, os.ModePerm)
+		err = os.MkdirAll(dataDirPath, os.ModePerm)
 		if err != nil {
 			log.DefaultLogger.Error("Cannot create data directory", "error", err)
 		}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -720,6 +720,7 @@ export default class StravaDatasource extends DataSourceApi<StravaQuery, StravaJ
 
     try {
       await this.stravaApi.resetAccessToken();
+      await this.stravaApi.resetCache();
       const athlete = await this.stravaApi.getAuthenticatedAthlete();
       if (!athlete) {
         return { status: 'error', message: `Cannot get authenticated user.` };

--- a/src/stravaApi.ts
+++ b/src/stravaApi.ts
@@ -85,6 +85,16 @@ export default class StravaApi {
     }
   }
 
+  async resetCache() {
+    try {
+      const response = await getBackendSrv().get(`/api/datasources/${this.datasourceId}/resources/reset-cache`);
+      return this.handleTsdbResponse(response);
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
+  }
+
   async request(url: string, params?: any) {
     return this.proxyfy(this._request, '_request', this)(url, params);
   }


### PR DESCRIPTION
This PR contains bug fixes for 1.5.0. 

### Fixed

- 401 Unauthorized when connecting to Strava API, [#62](https://github.com/grafana/strava-datasource/issues/62)
Refresh token now is not flushed when data source updated. Also, a disk cache is more reliable (works in grafana docker image).