### PR TITLE
Chore: removes props mutation

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,2 +1,5 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfigEditor } from './ConfigEditor';
+import { DataSourceSettings } from '@grafana/data';
+import { StravaJsonData, StravaSecureJsonData } from 'types';
+
+describe('ConfigEditor', () => {
+  describe('on initial render', () => {
+    it('should not mutate the options object', () => {
+      const options = Object.freeze({ ...defaultOptions }); // freezing the options to prevent mutations
+      Object.freeze(options.jsonData);
+      Object.freeze(options.secureJsonData);
+      Object.freeze(options.secureJsonFields);
+      const onOptionsChangeSpy = jest.fn();
+
+      expect(() => render(<ConfigEditor options={options} onOptionsChange={onOptionsChangeSpy} />)).not.toThrow();
+    });
+
+    it('should call onOptionsChange and remove any empty props in jsonData and secureJsonData', () => {
+      const options = Object.freeze({ ...defaultOptions }); // freezing the options to prevent mutations
+      Object.freeze(options.jsonData);
+      Object.freeze(options.secureJsonData);
+      Object.freeze(options.secureJsonFields);
+      const onOptionsChangeSpy = jest.fn();
+
+      expect(() => render(<ConfigEditor options={options} onOptionsChange={onOptionsChangeSpy} />)).not.toThrow();
+      expect(onOptionsChangeSpy).toHaveBeenCalledTimes(1);
+      expect(onOptionsChangeSpy).toHaveBeenCalledWith({
+        ...defaultOptions,
+        jsonData: { oauthPassThru: false },
+        secureJsonData: {},
+      });
+    });
+
+    it('should set defaults that are missing', () => {
+      const options: any = { ...defaultOptions };
+      delete options.secureJsonData;
+      delete options.secureJsonFields;
+      delete options.jsonData;
+      const frozen = Object.freeze(options); // freezing the options to prevent mutations
+      const onOptionsChangeSpy = jest.fn();
+
+      expect(() =>
+        render(<ConfigEditor options={Object.freeze(frozen)} onOptionsChange={onOptionsChangeSpy} />)
+      ).not.toThrow();
+      expect(onOptionsChangeSpy).toHaveBeenCalledTimes(1);
+      expect(onOptionsChangeSpy).toHaveBeenCalledWith({
+        ...defaultOptions,
+        jsonData: {},
+        secureJsonData: {},
+        secureJsonFields: {},
+      });
+    });
+  });
+});
+
+const defaultOptions: DataSourceSettings<StravaJsonData, StravaSecureJsonData> = {
+  id: 1,
+  orgId: 1,
+  uid: 'xyz',
+  name: 'strava',
+  typeLogoUrl: '',
+  type: '',
+  typeName: '',
+  access: '',
+  url: '',
+  user: '',
+  database: '',
+  basicAuth: false,
+  basicAuthUser: '',
+  isDefault: false,
+  jsonData: {
+    cacheTTL: '',
+    clientID: '',
+    oauthPassThru: false,
+  },
+  readOnly: false,
+  secureJsonData: {
+    clientSecret: '',
+  },
+  secureJsonFields: {},
+  withCredentials: false,
+};


### PR DESCRIPTION
While investigating some potential mutations [here](https://ops.grafana-ops.net/d/83f4951f-2ef3-4260-91a0-39a031992b75/getmutationobserverproxy-logs) I was able to find this mutating line in src/components/ConfigEditor.tsx. 

Although this works right now, this might not work in future Grafana versions. This PR makes sure we don't mutate the props.

I haven't been able to test this manually so I could use some help to make sure the plugin works as expected.